### PR TITLE
update tflint v0.13.4 and tfsec v0.13.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM hashicorp/terraform:light
 MAINTAINER Jesse DeFer <terragrunt@dotd.com>
 
 ENV TERRAGRUNT_VERSION=0.21.5
-ENV TFLINT_VERSION=0.12.1
-ENV TFSEC_VERSION=0.12.1
+ENV TFLINT_VERSION=0.13.4
+ENV TFSEC_VERSION=0.13.0
 ENV TF_IN_AUTOMATION true
 
 RUN apk add --no-cache --update git openssh-client curl


### PR DESCRIPTION
tflint now has https://github.com/terraform-linters/tflint/pull/541: latest lambda runtimes for nodejs, java, and python